### PR TITLE
add options to the restemitter to accept cert

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -49,7 +49,7 @@ class DatahubRestEmitter:
     _session: requests.Session
     _connect_timeout_sec: float = DEFAULT_CONNECT_TIMEOUT_SEC
     _read_timeout_sec: float = DEFAULT_READ_TIMEOUT_SEC
-    _ca_cert: str = None
+    _ca_cert: Union[None, str] = None
 
     def __init__(
         self,
@@ -57,7 +57,7 @@ class DatahubRestEmitter:
         token: Optional[str] = None,
         connect_timeout_sec: Optional[float] = None,
         read_timeout_sec: Optional[float] = None,
-        ca_cert: Optional[str]=None,
+        ca_cert: Optional[str] = None,
     ):
         if ":9002" in gms_server:
             logger.warning(
@@ -65,6 +65,7 @@ class DatahubRestEmitter:
             )
         self._gms_server = gms_server
         self._token = token
+        self._ca_cert = ca_cert
 
         self._session = requests.Session()
         self._session.headers.update(
@@ -75,8 +76,7 @@ class DatahubRestEmitter:
         )
         if token:
             self._session.headers.update({"Authorization": f"Bearer {token}"})
-        
-        self._ca_cert = ca_cert
+
         if self._ca_cert:
             self._session.verify = self._ca_cert
 

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -49,6 +49,7 @@ class DatahubRestEmitter:
     _session: requests.Session
     _connect_timeout_sec: float = DEFAULT_CONNECT_TIMEOUT_SEC
     _read_timeout_sec: float = DEFAULT_READ_TIMEOUT_SEC
+    _ca_cert: str = None
 
     def __init__(
         self,
@@ -56,6 +57,7 @@ class DatahubRestEmitter:
         token: Optional[str] = None,
         connect_timeout_sec: Optional[float] = None,
         read_timeout_sec: Optional[float] = None,
+        ca_cert: Optional[str]=None,
     ):
         if ":9002" in gms_server:
             logger.warning(
@@ -73,6 +75,10 @@ class DatahubRestEmitter:
         )
         if token:
             self._session.headers.update({"Authorization": f"Bearer {token}"})
+        
+        self._ca_cert = ca_cert
+        if self._ca_cert:
+            self._session.verify = self._ca_cert
 
         if connect_timeout_sec:
             self._connect_timeout_sec = connect_timeout_sec

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -22,6 +22,7 @@ class DatahubRestSinkConfig(ConfigModel):
     server: str = "http://localhost:8080"
     token: Optional[str]
     timeout_sec: Optional[int]
+    ca_cert: Optional[str]
 
 
 @dataclass
@@ -39,6 +40,7 @@ class DatahubRestSink(Sink):
             self.config.token,
             connect_timeout_sec=self.config.timeout_sec,  # reuse timeout_sec for connect timeout
             read_timeout_sec=self.config.timeout_sec,
+            ca_cert = self.config.ca_cert
         )
         self.emitter.test_connection()
 

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -40,7 +40,7 @@ class DatahubRestSink(Sink):
             self.config.token,
             connect_timeout_sec=self.config.timeout_sec,  # reuse timeout_sec for connect timeout
             read_timeout_sec=self.config.timeout_sec,
-            ca_cert = self.config.ca_cert
+            ca_cert=self.config.ca_cert,
         )
         self.emitter.test_connection()
 


### PR DESCRIPTION
#31 
tested in office setup.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
