### PR TITLE
1) use urn to compare ownership instead since it is a common fields f…

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -30,10 +30,11 @@ import { GetMlModelDocument } from './graphql/mlModel.generated';
 import { GetMlModelGroupDocument } from './graphql/mlModelGroup.generated';
 import { GetGlossaryTermDocument, GetGlossaryTermQuery } from './graphql/glossaryTerm.generated';
 import { GetEntityCountsDocument } from './graphql/app.generated';
-import { GetMeDocument, GetMeOnlyDocument } from './graphql/me.generated';
+import { GetMeDocument } from './graphql/me.generated';
 import { ListRecommendationsDocument } from './graphql/recommendations.generated';
 
 const user1 = {
+    __typename: 'CorpUser',
     username: 'sdas',
     urn: 'urn:li:corpuser:1',
     type: EntityType.CorpUser,
@@ -64,10 +65,12 @@ const user1 = {
 };
 
 const user2 = {
+    __typename: 'CorpUser',
     username: 'john',
     urn: 'urn:li:corpuser:3',
     type: EntityType.CorpUser,
     info: {
+        __typename: 'CorpUserInfo',
         email: 'john@domain.com',
         active: true,
         displayName: 'john',
@@ -77,7 +80,10 @@ const user2 = {
         fullName: 'John Joyce',
     },
     editableInfo: {
+        __typename: 'CorpUserEditableInfo',
         pictureLink: null,
+        teams: null,
+        skills: null,
     },
     globalTags: {
         tags: [
@@ -2645,26 +2651,6 @@ export const mocks = [
     },
     {
         request: {
-            query: GetMeDocument,
-            variables: {},
-        },
-        result: {
-            data: {
-                __typename: 'Query',
-                me: {
-                    __typename: 'AuthenticatedUser',
-                    corpUser: { ...user2 },
-                    platformPrivileges: {
-                        viewAnalytics: true,
-                        managePolicies: true,
-                        manageIdentities: true,
-                    },
-                },
-            },
-        },
-    },
-    {
-        request: {
             query: ListRecommendationsDocument,
             variables: {
                 input: {
@@ -2791,9 +2777,8 @@ export const mocks = [
         },
     },
     {
-        // this mock can be shifted elsewhere in the doc. need to create new mock instead of recycling cos it needs to be specific to query else it doesnt work
         request: {
-            query: GetMeOnlyDocument,
+            query: GetMeDocument,
             variables: {},
         },
         result: {
@@ -2801,10 +2786,16 @@ export const mocks = [
                 __typename: 'Query',
                 me: {
                     __typename: 'AuthenticatedUser',
-                    corpUser: {
-                        type: EntityType.CorpUser,
-                        username: 'john',
-                        urn: 'urn:li:corpuser:3',
+                    corpUser: { ...user2 },
+                    platformPrivileges: {
+                        __typename: 'PlatformPrivileges',
+                        viewAnalytics: true,
+                        managePolicies: true,
+                        manageIdentities: true,
+                        generatePersonalAccessTokens: true,
+                        manageIngestion: true,
+                        manageSecrets: true,
+                        manageDomains: true,
                     },
                 },
             },

--- a/datahub-web-react/src/MocksCustom.tsx
+++ b/datahub-web-react/src/MocksCustom.tsx
@@ -1,44 +1,13 @@
 import { GetDatasetDocument } from './graphql/dataset.generated';
 import { Dataset, EntityType, PlatformType, SchemaFieldDataType } from './types.generated';
-import { GetMeOnlyDocument } from './graphql/me.generated';
-// I had to make a new mock file cos the original mock file, ownership of dataset and the mock identity of the person visiting the schema pages is not the same
-// hence cannot test the edit schema functionality.
+import { GetMeDocument } from './graphql/me.generated';
 
-const user1 = {
-    username: '1',
-    urn: 'urn:li:corpuser:1',
-    type: EntityType.CorpUser,
-    info: {
-        email: 'sdas@domain.com',
-        active: true,
-        displayName: 'sdas',
-        title: 'Software Engineer',
-        firstName: 'Shirshanka',
-        lastName: 'Das',
-        fullName: 'Shirshanka Das',
-    },
-    editableInfo: {
-        pictureLink: 'https://crunchconf.com/img/2019/speakers/1559291783-ShirshankaDas.png',
-    },
-    globalTags: {
-        tags: [
-            {
-                tag: {
-                    type: EntityType.Tag,
-                    urn: 'urn:li:tag:abc-sample-tag',
-                    name: 'abc-sample-tag',
-                    description: 'sample tag',
-                },
-            },
-        ],
-    },
-};
-
-const user2 = {
+const user = {
     username: 'john',
     urn: 'urn:li:corpuser:3',
     type: EntityType.CorpUser,
     info: {
+        __typename: 'CorpUserInfo',
         email: 'john@domain.com',
         active: true,
         displayName: 'john',
@@ -49,6 +18,8 @@ const user2 = {
     },
     editableInfo: {
         pictureLink: null,
+        teams: null,
+        skills: null,
     },
     globalTags: {
         tags: [
@@ -80,9 +51,9 @@ export const dataset3 = {
         type: EntityType.DataPlatform,
     },
     platformNativeType: 'STREAM',
-    name: 'Yet Another Dataset2',
+    name: 'Yet Another Dataset',
     origin: 'PROD',
-    uri: 'www.google.comx',
+    uri: 'www.google.com',
     properties: {
         description: 'This and here we have yet another Dataset (YAN). Are there more?',
         origin: 'PROD',
@@ -100,19 +71,10 @@ export const dataset3 = {
         owners: [
             {
                 owner: {
-                    ...user1,
+                    ...user,
                     __typename: 'CorpUser',
                 },
                 type: 'DATAOWNER',
-                __typename: 'Owner',
-            },
-            {
-                owner: {
-                    ...user2,
-                    __typename: 'CorpUser',
-                },
-                type: 'DELEGATE',
-                __typename: 'Owner',
             },
         ],
         lastModified: {
@@ -217,6 +179,7 @@ export const dataset3 = {
     editableSchemaMetadata: null,
     deprecation: null,
     usageStats: null,
+    operations: null,
     datasetProfiles: [
         {
             rowCount: 10,
@@ -252,15 +215,17 @@ export const dataset3 = {
             },
         },
     ],
+    domain: null,
+    container: null,
     status: {
         removed: false,
     },
 } as Dataset;
 
 /*
-    Define mock data to be returned by Apollo MockProvider. 
+    Define mock data to be returned by Apollo MockProvider.
 */
-export const mocks2 = [
+export const editMocks = [
     {
         request: {
             query: GetDatasetDocument,
@@ -276,40 +241,23 @@ export const mocks2 = [
             },
         },
     },
-    // {
-    //     request: {
-    //         query: GetMeDocument,
-    //         variables: {},
-    //     },
-    //     result: {
-    //         data: {
-    //             __typename: 'Query',
-    //             me: {
-    //                 __typename: 'AuthenticatedUser',
-    //                 corpUser: { ...user2 },
-    //                 platformPrivileges: {
-    //                     viewAnalytics: true,
-    //                     managePolicies: true,
-    //                     manageIdentities: true,
-    //                 },
-    //             },
-    //         },
-    //     },
-    // },
-
     {
-        // this mock can be shifted elsewhere in the doc. need to create new mock instead of recycling cos it needs to be specific to query else it doesnt work
         request: {
-            query: GetMeOnlyDocument,
+            query: GetMeDocument,
             variables: {},
         },
         result: {
             data: {
-                __typename: 'Query',
                 me: {
-                    corpUser: {
-                        username: '1',
-                        urn: 'urn:li:corpuser:1',
+                    corpUser: { ...user },
+                    platformPrivileges: {
+                        viewAnalytics: true,
+                        managePolicies: true,
+                        manageIdentities: true,
+                        generatePersonalAccessTokens: true,
+                        manageIngestion: true,
+                        manageSecrets: true,
+                        manageDomains: true,
                     },
                 },
             },

--- a/datahub-web-react/src/app/entity/dataset/whoAmI.tsx
+++ b/datahub-web-react/src/app/entity/dataset/whoAmI.tsx
@@ -1,29 +1,27 @@
 // import * as React from 'react';
 import { gql, useQuery } from '@apollo/client';
-import { GetMeOnlyDocument } from '../../../graphql/me.generated';
+import { useGetMeQuery } from '../../../graphql/me.generated';
 import { GetDatasetQuery } from '../../../graphql/dataset.generated';
+import { EntityType } from '../../../types.generated';
 
 export function FindWhoAmI() {
-    const { loading, data } = useQuery(GetMeOnlyDocument);
-    if (loading) return 'loading..';
-    return data.me.corpUser.username;
-}
-
-export function checkOwnership(data: GetDatasetQuery): boolean {
-    const currUser = FindWhoAmI();
-    const ownership = data?.dataset?.ownership?.owners;
-    const ownersArray =
-        ownership?.map((x) =>
-            x?.type === 'DATAOWNER' && x?.owner?.__typename === 'CorpUser' ? x?.owner?.username : '',
-        ) || [];
-
-    return ownersArray.includes(currUser);
+    const { data } = useGetMeQuery();
+    return data?.me?.corpUser.username ?? '';
 }
 
 export function FindMyUrn() {
-    const { loading, data } = useQuery(GetMeOnlyDocument);
-    if (loading) return '';
-    return data.me.corpUser.urn;
+    const { data } = useGetMeQuery();
+    return data?.me?.corpUser.urn ?? '';
+}
+
+export function checkOwnership(data: GetDatasetQuery): boolean {
+    const currUserUrn = FindMyUrn();
+    const ownership = data?.dataset?.ownership?.owners;
+    const ownersArray =
+        ownership?.map((x) =>
+            x?.type === 'DATAOWNER' && x?.owner?.type === EntityType.CorpUser ? x?.owner?.urn : null,
+        ) || [];
+    return ownersArray.includes(currUserUrn);
 }
 
 export function GetMyToken(userUrn: string) {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfileEdit.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfileEdit.test.tsx
@@ -3,7 +3,6 @@ import { render, waitFor, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
 import TestPageContainer from '../../../../../../utils/test-utils/TestPageContainer';
-import { mocks } from '../../../../../../Mocks';
 import { EntityProfile } from '../EntityProfile';
 import {
     useGetDatasetQuery,
@@ -16,11 +15,12 @@ import { EditSchemaTab } from '../../../tabs/Dataset/Schema/EditSchemaTab';
 import { checkOwnership } from '../../../../dataset/whoAmI';
 import { EditPropertiesTab } from '../../../tabs/Dataset/Schema/EditPropertiesTab';
 import { AdminTab } from '../../../tabs/Dataset/Schema/AdminTab';
+import { editMocks } from '../../../../../../MocksCustom';
 
 describe('EntityProfile Edit', () => {
     it('Render edit tabs as authorised data owner', async () => {
         const { getByText } = render(
-            <MockedProvider mocks={mocks}>
+            <MockedProvider mocks={editMocks} addTypename={false}>
                 <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
                     <EntityProfile
                         urn="urn:li:dataset:3"
@@ -63,7 +63,7 @@ describe('EntityProfile Edit', () => {
     });
     it('Render edit properties as authorised data owner', async () => {
         const { getByText } = render(
-            <MockedProvider mocks={mocks}>
+            <MockedProvider mocks={editMocks} addTypename={false}>
                 <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
                     <EntityProfile
                         urn="urn:li:dataset:3"
@@ -113,7 +113,7 @@ describe('EntityProfile Edit', () => {
 
     it('Render dataset admin properties as authorised data owner', async () => {
         const { getByText } = render(
-            <MockedProvider mocks={mocks}>
+            <MockedProvider mocks={editMocks} addTypename={false}>
                 <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
                     <EntityProfile
                         urn="urn:li:dataset:3"

--- a/datahub-web-react/src/utils/test-utils/TestPageContainer.tsx
+++ b/datahub-web-react/src/utils/test-utils/TestPageContainer.tsx
@@ -46,10 +46,9 @@ export default ({ children, initialEntries }: Props) => {
     const entityRegistry = useMemo(() => getTestEntityRegistry(), []);
     Object.defineProperty(window.document, 'cookie', {
         writable: true,
-        value: `${CLIENT_AUTH_COOKIE}=urn:li:corpuser:2`,
+        value: `${CLIENT_AUTH_COOKIE}=urn:li:corpuser:test`,
     });
-    jest.mock('js-cookie', () => ({ get: () => 'urn:li:corpuser:2' }));
-
+    jest.mock('js-cookie', () => ({ get: () => 'urn:li:corpusertest' }));
     return (
         <ThemeProvider theme={defaultThemeConfig}>
             <MemoryRouter initialEntries={initialEntries}>


### PR DESCRIPTION
1) use urn to compare ownership instead since it is a common fields for both corpuser and corpgroup. For common fields between fragments (corpuser and corpgroup), you do not need to check for __typename
2) disable addTypename as recommended by mockprovider graphql to compare the shape of response against generated graphql ts file.  Only fragments such as ownership fragment needs to add __typename manually
3) use mock custom for edit tabs. to limit conflict in the user
4) use getmedocument to check for current user and urn instead.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
