### PR TITLE
Keycloak resource access authorization

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -157,10 +157,12 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
             // check for access role
             if(!roleLists.get().equals(oidcConfigs.getResourceClientRole().get()))
               return internalServerError(String.format("Failed to pass authorization-with-keycloak step. " +
-                      "Please ensure that you have the required role to access this app"));
+                      "Please ensure that you have the required role to access this app: %s:%s",
+                      oidcConfigs.getClientId(),oidcConfigs.getResourceClientRole().get()));
           } else {
             return internalServerError(String.format("Failed to pass authorization-with-keycloak step. " +
-                    "Please ensure that you have the required role to access this app"));
+                            "Please ensure that you have the required role to access this app: %s:%s",
+                    oidcConfigs.getClientId(),oidcConfigs.getResourceClientRole().get()));
           }
         }
 

--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -155,7 +155,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
           // check if it is populated
           if(roleLists.isPresent()){
             // check for access role
-            if(!roleLists.get().contains(oidcConfigs.getResourceClientRole().get()))
+            if(!roleLists.get().equals(oidcConfigs.getResourceClientRole().get()))
               return internalServerError(String.format("Failed to pass authorization-with-keycloak step. " +
                       "Please ensure that you have the required role to access this app"));
           } else {

--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -121,7 +121,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
 
       // If authenticated, the user should have a profile.
       final CommonProfile profile = profileManager.get(true).get();
-      log.info(String.format("Checking the attributes of the profile: %s", profile.getAttributes().toString()));
+      log.debug(String.format("Checking the attributes of the profile: %s", profile.getAttributes().toString()));
 
       // determine if we want to extract client roles through customParamResource
       // using client-id and client_role "access"
@@ -187,7 +187,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
     // Ensure that the attribute exists (was returned by keycloak)
     if (profile.containsAttribute("resource_access")) {
       final String resourceAccessJsonStr = profile.getAttribute("resource_access").toString();
-      log.info(String.format("Examining resource_access attribute: %s", resourceAccessJsonStr));
+      log.debug(String.format("Examining resource_access attribute: %s", resourceAccessJsonStr));
       ObjectMapper objectMapper = new ObjectMapper();
       try {
         JsonNode jsonNode = objectMapper.readTree(resourceAccessJsonStr);
@@ -198,7 +198,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
                 .collect(Collectors.toList()));
 
       } catch (JsonProcessingException e) {
-        log.info("Failed to extract roles.", e);
+        log.error("Failed to extract roles.", e);
       }
     }
 

--- a/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
@@ -37,6 +37,8 @@ public class OidcConfigs extends SsoConfigs {
     public static final String OIDC_USE_NONCE = "auth.oidc.useNonce";
     public static final String OIDC_CUSTOM_PARAM_RESOURCE = "auth.oidc.customParam.resource";
 
+    public static final String OIDC_RESOURCE_CLIENT_ROLE = "auth.oidc.resource.clientRole";
+
     /**
      * Default values
      */
@@ -67,6 +69,8 @@ public class OidcConfigs extends SsoConfigs {
     private Optional<Boolean> useNonce;
     private Optional<String> customParamResource;
 
+    private Optional<String> resourceClientRole;
+
     public OidcConfigs(final com.typesafe.config.Config configs) {
         super(configs);
         clientId = getRequired(configs, OIDC_CLIENT_ID_CONFIG_PATH);
@@ -90,5 +94,7 @@ public class OidcConfigs extends SsoConfigs {
         responseMode = getOptional(configs, OIDC_RESPONSE_MODE);
         useNonce = getOptional(configs, OIDC_USE_NONCE).map(Boolean::parseBoolean);
         customParamResource = getOptional(configs, OIDC_CUSTOM_PARAM_RESOURCE);
+        resourceClientRole = getOptional(configs, OIDC_RESOURCE_CLIENT_ROLE);
+
     }
 }

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -125,7 +125,7 @@ auth.oidc.responseType = ${?AUTH_OIDC_RESPONSE_TYPE}
 auth.oidc.responseMode = ${?AUTH_OIDC_RESPONSE_MODE}
 auth.oidc.useNonce = ${?AUTH_OIDC_USE_NONCE}
 auth.oidc.customParam.resource = ${?AUTH_OIDC_CUSTOM_PARAM_RESOURCE}
-
+auth.oidc.resource.clientRole = ${?AUTH_OIDC_RESOURCE_CLIENT_ROLE}
 #
 # By default, the callback URL that should be registered with the identity provider is computed as {$baseUrl}/callback/oidc.
 # For example, the default callback URL for a local deployment of DataHub would be "http://localhost:9002/callback/oidc".


### PR DESCRIPTION
This pull request is to add a check in OidcCallbackLogic.java. The purpose is to check for the resource-access and client roles generated by keycloak. For the user to access datahub page, they need to have "access" role for this client app.  

AUTH_OIDC_RESOURCE_CLIENT_ROLE is a new optional conf that we can set in docker.env. Without setting it, it will not check for the client role. To note, this is the client role that you will check and let the users login to datahub.
example: 
AUTH_OIDC_RESOURCE_CLIENT_ROLE=access
  
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
