### PR TITLE
[draft feat] hide create_dataset behind policy

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -17,6 +17,10 @@ public class AuthorizationUtils {
     return isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_USERS_AND_GROUPS_PRIVILEGE);
   }
 
+  public static boolean canCreateAdhocDatasets(@Nonnull QueryContext context) {
+    return isAuthorized(context, Optional.empty(), PoliciesConfig.CREATE_DATASET_PRIVILEGE);
+  }
+
   public static boolean canGeneratePersonalAccessToken(@Nonnull QueryContext context) {
     return isAuthorized(context, Optional.empty(), PoliciesConfig.GENERATE_PERSONAL_ACCESS_TOKENS_PRIVILEGE);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
@@ -53,13 +53,14 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
 
         // 2. Get platform privileges
         final PlatformPrivileges platformPrivileges = new PlatformPrivileges();
-        platformPrivileges.setViewAnalytics(canViewAnalytics(context));
+        platformPrivileges.setViewAnalytics(canViewAnalytics(context));        
         platformPrivileges.setManagePolicies(canManagePolicies(context));
         platformPrivileges.setManageIdentities(canManageUsersGroups(context));
         platformPrivileges.setGeneratePersonalAccessTokens(canGeneratePersonalAccessToken(context));
         platformPrivileges.setManageDomains(canManageDomains(context));
         platformPrivileges.setManageIngestion(canManageIngestion(context));
         platformPrivileges.setManageSecrets(canManageSecrets(context));
+        platformPrivileges.setCreateAdhocDatasets(canCreateAdhocDatasets(context));
 
         // Construct and return authenticated user object.
         final AuthenticatedUser authUser = new AuthenticatedUser();
@@ -106,6 +107,13 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
    */
   private boolean canManageDomains(final QueryContext context) {
     return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.MANAGE_DOMAINS_PRIVILEGE);
+  }
+
+  /**
+   * Returns true if the authenticated user has privileges to create adhoc datasets
+   */
+  private boolean canCreateAdhocDatasets(final QueryContext context) {
+    return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.CREATE_DATASET_PRIVILEGE);
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/adhoc/AdhocCreateAuthUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/adhoc/AdhocCreateAuthUtils.java
@@ -1,0 +1,19 @@
+package com.linkedin.datahub.graphql.resolvers.adhoc;
+
+import com.datahub.authorization.Authorizer;
+import com.google.common.collect.ImmutableList;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import javax.annotation.Nonnull;
+import static com.linkedin.datahub.graphql.resolvers.AuthUtils.*;
+
+public class AdhocCreateAuthUtils {
+
+  public static boolean canCreateAdhocDatasets(@Nonnull QueryContext context) {
+    final Authorizer authorizer = context.getAuthorizer();
+    final String principal = context.getActorUrn();
+    return isAuthorized(principal, ImmutableList.of(PoliciesConfig.CREATE_DATASET_PRIVILEGE.getType()), authorizer);
+  }  
+
+  private AdhocCreateAuthUtils() { }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -12,6 +12,7 @@ import com.linkedin.datahub.graphql.generated.PoliciesConfig;
 import com.linkedin.datahub.graphql.generated.Privilege;
 import com.linkedin.datahub.graphql.generated.ResourcePrivileges;
 import com.linkedin.datahub.graphql.generated.VisualConfiguration;
+import com.linkedin.datahub.graphql.generated.CreateAdhocConfig;
 import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.version.GitVersion;
 import graphql.schema.DataFetcher;
@@ -30,7 +31,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
   private final IngestionConfiguration _ingestionConfiguration;
   private final AuthorizationConfiguration _authorizationConfiguration;
   private final boolean _supportsImpactAnalysis;
-  private final VisualConfiguration _visualConfiguration;
+  private final VisualConfiguration _visualConfiguration;  
 
   public AppConfigResolver(
       final GitVersion gitVersion,
@@ -80,12 +81,16 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
     final IdentityManagementConfig identityManagementConfig = new IdentityManagementConfig();
     identityManagementConfig.setEnabled(true); // Identity Management always enabled. TODO: Understand if there's a case where this should change.
 
+    final CreateAdhocConfig adhocConfig = new CreateAdhocConfig();
+    adhocConfig.setEnabled(true);
+
     final ManagedIngestionConfig ingestionConfig = new ManagedIngestionConfig();
     ingestionConfig.setEnabled(_ingestionConfiguration.isEnabled());
     appConfig.setAnalyticsConfig(analyticsConfig);
     appConfig.setPoliciesConfig(policiesConfig);
     appConfig.setIdentityManagementConfig(identityManagementConfig);
     appConfig.setManagedIngestionConfig(ingestionConfig);
+    appConfig.setCreateAdhocConfig(adhocConfig);
 
     appConfig.setVisualConfig(_visualConfiguration);
 

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -63,6 +63,11 @@ type PlatformPrivileges {
   manageIngestion: Boolean!
 
   """
+  Whether the user is create adhoc datasets using Ingest-API
+  """
+  createAdhocDatasets: Boolean!
+
+  """
   Whether the user is able to manage UI-based secrets
   """
   manageSecrets: Boolean!
@@ -97,6 +102,11 @@ type AppConfig {
   Configurations related to UI-based ingestion
   """
   managedIngestionConfig: ManagedIngestionConfig!
+
+  """
+  Configurations related to Adhoc Creation
+  """
+  createAdhocConfig: CreateAdhocConfig!
 
   """
   Configurations related to Lineage
@@ -219,6 +229,16 @@ type IdentityManagementConfig {
 Configurations related to managed, UI based ingestion
 """
 type ManagedIngestionConfig {
+  """
+  Whether ingestion screen is enabled in the UI
+  """
+  enabled: Boolean!
+}
+
+"""
+Configurations related to adhoc creation of datasets
+"""
+type CreateAdhocConfig {
   """
   Whether ingestion screen is enabled in the UI
   """

--- a/datahub-web-react/src/MocksCustom.tsx
+++ b/datahub-web-react/src/MocksCustom.tsx
@@ -297,6 +297,7 @@ export const editMocks = [
                         manageIngestion: true,
                         manageSecrets: true,
                         manageDomains: true,
+                        createAdhocDatasets: true,
                     },
                 },
             },

--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -14,6 +14,7 @@ import { ManageIdentitiesPage } from './identity/ManageIdentitiesPage';
 import { SettingsPage } from './settings/SettingsPage';
 import { ManageIngestionPage } from './ingest/ManageIngestionPage';
 import { ManageDomainsPage } from './domain/ManageDomainsPage';
+import { AdHocPage } from './create/AdHocPage';
 
 /**
  * Container for all views behind an authentication wall.
@@ -36,6 +37,7 @@ export const ProtectedRoutes = (): JSX.Element => {
                         <Route path={PageRoutes.SEARCH_RESULTS} render={() => <SearchPage />} />
                         <Route path={PageRoutes.BROWSE_RESULTS} render={() => <BrowseResultsPage />} />
                         <Route path={PageRoutes.ANALYTICS} render={() => <AnalyticsPage />} />
+                        <Route path={PageRoutes.ADHOC} render={() => <AdHocPage />} />
                         <Route path={PageRoutes.POLICIES} render={() => <PoliciesPage />} />
                         <Route path={PageRoutes.IDENTITIES} render={() => <ManageIdentitiesPage />} />
                         <Route path={PageRoutes.DOMAINS} render={() => <ManageDomainsPage />} />

--- a/datahub-web-react/src/app/Routes.tsx
+++ b/datahub-web-react/src/app/Routes.tsx
@@ -6,7 +6,7 @@ import { NoPageFound } from './shared/NoPageFound';
 import { PageRoutes } from '../conf/Global';
 import { isLoggedInVar } from './auth/checkAuthStatus';
 import { useTrackPageView } from './analytics';
-import { AdHocPage } from './create/AdHocPage';
+// import { AdHocPage } from './create/AdHocPage';
 import { ProtectedRoutes } from './ProtectedRoutes';
 
 const ProtectedRoute = ({
@@ -33,7 +33,7 @@ export const Routes = (): JSX.Element => {
     return (
         <Switch>
             <Route path={PageRoutes.LOG_IN} component={LogIn} />
-            <ProtectedRoute isLoggedIn={isLoggedIn} path={PageRoutes.ADHOC} render={() => <AdHocPage />} />
+            {/* <ProtectedRoute isLoggedIn={isLoggedIn} path={PageRoutes.ADHOC} render={() => <AdHocPage />} /> */}
             <ProtectedRoute isLoggedIn={isLoggedIn} render={() => <ProtectedRoutes />} />
             {/* Starting the react app locally opens /assets by default. For a smoother dev experience, we'll redirect to the homepage */}
             <Route path={PageRoutes.ASSETS} component={() => <Redirect to="/" />} exact />

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../graphql/search.generated';
 import { EntityType } from '../../types.generated';
 import analytics, { EventType } from '../analytics';
-import AdhocLink from '../create/AdhocLink';
 import HelpLink from '../shared/admin/HelpLink';
 import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
 import { ANTD_GRAY } from '../entity/shared/constants';
@@ -191,7 +190,6 @@ export const HomePageHeader = () => {
                 <NavGroup>
                     <ContactLink />
                     <HelpLink />
-                    <AdhocLink />
                     <AdminHeaderLinks />
                     <ManageAccount
                         urn={user?.urn || ''}

--- a/datahub-web-react/src/app/search/SearchHeader.tsx
+++ b/datahub-web-react/src/app/search/SearchHeader.tsx
@@ -7,7 +7,6 @@ import { SearchBar } from './SearchBar';
 import { ManageAccount } from '../shared/ManageAccount';
 import { AutoCompleteResultForEntity, EntityType } from '../../types.generated';
 import EntityRegistry from '../entity/EntityRegistry';
-import AdhocLink from '../create/AdhocLink';
 import HelpLink from '../shared/admin/HelpLink';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
@@ -102,7 +101,6 @@ export const SearchHeader = ({
             <NavGroup>
                 <ContactLink />
                 <HelpLink />
-                <AdhocLink />
                 <AdminHeaderLinks />
                 <ManageAccount urn={authenticatedUserUrn} pictureLink={authenticatedUserPictureLink || ''} />
             </NavGroup>

--- a/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
+++ b/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
@@ -7,6 +7,7 @@ import {
     SettingOutlined,
     UsergroupAddOutlined,
     FolderOutlined,
+    EditOutlined,
 } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { Button } from 'antd';
@@ -25,8 +26,10 @@ export function AdminHeaderLinks() {
     const isPoliciesEnabled = config?.policiesConfig.enabled;
     const isIdentityManagementEnabled = config?.identityManagementConfig.enabled;
     const isIngestionEnabled = config?.managedIngestionConfig.enabled;
+    const isAdhocCreateEnabled = config?.createAdhocConfig.enabled;
 
     const showAnalytics = (isAnalyticsEnabled && me && me.platformPrivileges.viewAnalytics) || false;
+    const showAdhoc = (isAdhocCreateEnabled && me && me.platformPrivileges.createAdhocDatasets) || false;
     const showPolicyBuilder = (isPoliciesEnabled && me && me.platformPrivileges.managePolicies) || false;
     const showIdentityManagement =
         (isIdentityManagementEnabled && me && me.platformPrivileges.manageIdentities) || false;
@@ -37,6 +40,15 @@ export function AdminHeaderLinks() {
 
     return (
         <>
+            {showAdhoc && (
+                <AdminLink>
+                    <Link to="/adhoc/">
+                        <Button type="text">
+                            <EditOutlined /> Create Dataset
+                        </Button>
+                    </Link>
+                </AdminLink>
+            )}
             {showAnalytics && (
                 <AdminLink>
                     <Link to="/analytics">

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -13,6 +13,9 @@ export const DEFAULT_APP_CONFIG = {
     identityManagementConfig: {
         enabled: false,
     },
+    createAdhocConfig: {
+        enabled: false,
+    },
     managedIngestionConfig: {
         enabled: false,
     },

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -28,6 +28,9 @@ query appConfig {
         lineageConfig {
             supportsImpactAnalysis
         }
+        createAdhocConfig{
+            enabled
+        }
         managedIngestionConfig {
             enabled
         }

--- a/datahub-web-react/src/graphql/me.graphql
+++ b/datahub-web-react/src/graphql/me.graphql
@@ -28,6 +28,7 @@ query getMe {
             manageIngestion
             manageSecrets
             manageDomains
+            createAdhocDatasets
         }
     }
 }

--- a/ingest-api/ingest_api/helper/security.py
+++ b/ingest-api/ingest_api/helper/security.py
@@ -167,3 +167,29 @@ def query_users_groups(token: str, query_endpoint: str):
         return groups_list
     log.debug(f"group membership list is empty")
     return []
+
+def query_platform_rights_adhoc_create(token: str, query_endpoint: str):
+    headers = {}
+    headers["Authorization"] = f"Bearer {token}"
+    headers["Content-Type"] = "application/json"
+    query = """
+        query userRights{
+            me{
+                platformPrivileges{
+                    createAdhocDatasets
+                }
+            }
+        }
+    """    
+    resp = requests.post(
+        query_endpoint, headers=headers, json={"query": query }
+    )
+    log.debug(f"group membership resp.status_code is {resp.status_code}")
+    if resp.status_code != 200:
+        return False
+    data_received = json.loads(resp.text)
+    if data_received["data"]["me"]["platformPrivileges"]["createAdhocDatasets"] == True:
+        log.debug(f"create_dataset rights is True")
+        return True
+    log.debug(f"create_dataset rights is False")
+    return False

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -72,7 +72,8 @@ sql_common = {
     # Required for all SQL sources.
     "sqlalchemy==1.3.24",
     # Required for SQL profiling.
-    "great-expectations>=0.14.11",
+    # due to new version in great expectation causing methods to fail.
+    "great-expectations>=0.14.11, <=0.15.2",
     # datahub does not depend on Jinja2 directly but great expectations does. With Jinja2 3.1.0 GE 0.14.11 is breaking
     "Jinja2<3.1.0",
     "greenlet",

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_ENV = DEFAULT_ENV_CONFIGURATION
 DEFAULT_FLOW_CLUSTER = "prod"
 UNKNOWN_USER = "urn:li:corpuser:unknown"
-DATASET_URN_TO_LOWER: bool = strtobool(
-    os.getenv("DATAHUB_DATASET_URN_TO_LOWER", "false")
+DATASET_URN_TO_LOWER: bool = (
+    os.getenv("DATAHUB_DATASET_URN_TO_LOWER", "false") == "true"
 )
 
 

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import time
-from distutils.util import strtobool
 from enum import Enum
 from hashlib import md5
 from typing import Any, List, Optional, Type, TypeVar, Union, cast, get_type_hints

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -830,7 +830,7 @@ class LookerDashboardSource(Source):
             max_workers=self.source_config.max_threads
         ) as async_executor:
             async_workunits = [
-                async_executor.submit(self.process_dashboard, dashboard_id)
+                async_executor.submit(self.process_dashboard, str(dashboard_id))
                 for dashboard_id in dashboard_ids
             ]
             for async_workunit in concurrent.futures.as_completed(async_workunits):

--- a/metadata-service/war/src/main/resources/boot/policies.json
+++ b/metadata-service/war/src/main/resources/boot/policies.json
@@ -11,6 +11,7 @@
         ]
       },
       "privileges":[
+        "CREATE_ADHOC_DATASET",
         "MANAGE_POLICIES",
         "MANAGE_INGESTION",
         "MANAGE_SECRETS",

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -22,6 +22,11 @@ public class PoliciesConfig {
 
   // Platform Privileges //
 
+  public static final Privilege CREATE_DATASET_PRIVILEGE = Privilege.of(
+      "CREATE_ADHOC_DATASET",
+      "Create Adhoc Datasets",
+      "Ability to use the UI form and API to create datasets");
+
   public static final Privilege MANAGE_POLICIES_PRIVILEGE = Privilege.of(
       "MANAGE_POLICIES",
       "Manage Policies",
@@ -65,6 +70,7 @@ public class PoliciesConfig {
       MANAGE_DOMAINS_PRIVILEGE,
       MANAGE_INGESTION_PRIVILEGE,
       MANAGE_SECRETS_PRIVILEGE,
+      CREATE_DATASET_PRIVILEGE,
       GENERATE_PERSONAL_ACCESS_TOKENS_PRIVILEGE
   );
 


### PR DESCRIPTION
The intent is to add an additional platform policy to selectively expose create_dataset to selected users. Ingest-api will also check via graphql to see if user has the rights to create dataset and reject those without the rights.
The java code changes were done by following the existing policies in place.\
For now, just checking to see if the tests will pass.