### PR TITLE
reduce logging for restclient

### DIFF
--- a/ingest-api/ingest_api/helper/mce_convenience.py
+++ b/ingest-api/ingest_api/helper/mce_convenience.py
@@ -427,7 +427,7 @@ def check_platform_container_test(item: create_dataset_params):
         return True
     query_endpoint = urljoin(datahub_url, "/api/graphql")
     container_urn = item.parentContainer
-    token = item.user_token
+    token = item.user_token.get_secret_value()
     headers = {}
     headers["Authorization"] = f"Bearer {token}"
     headers["Content-Type"] = "application/json"

--- a/ingest-api/ingest_api/main.py
+++ b/ingest-api/ingest_api/main.py
@@ -202,7 +202,7 @@ async def update_browsepath(item: browsepath_params):
         )
         all_paths = []
         for path in item.browsePaths:
-            all_paths.append(path['browsepath'] + "dataset")
+            all_paths.append(path['browsepath'])
         browsepath_aspect = make_browsepath_mce(path=all_paths)
         dataset_snapshot.aspects.append(browsepath_aspect)
         metadata_record = MetadataChangeEvent(
@@ -520,7 +520,7 @@ async def create_item(item: create_dataset_params) -> None:
         ]
         # this line is in case the endpoint is called by API and not UI,
         # which will enforce ending with /.
-        browsepaths = [path + "dataset" for path in browsepathList]        
+        browsepaths = [path for path in browsepathList]        
         properties = {
             "dataset_origin": item.dict().get("dataset_origin", ""),
             "dataset_location": item.dict().get("dataset_location", ""),

--- a/ingest-api/ingest_api/main.py
+++ b/ingest-api/ingest_api/main.py
@@ -215,7 +215,7 @@ async def update_browsepath(item: browsepath_params):
             metadata_record=metadata_record,
             owner=item.requestor,
             event="UI Update Browsepath",
-            token=item.user_token,
+            token=token,
             eventid=eventid,
         )
         
@@ -248,7 +248,7 @@ async def update_samples(item: add_sample_params):
             metadata_record=generated_mcp,
             owner=item.requestor,
             event="Update Dataset Profile",
-            token=item.user_token,
+            token=token,
         )
         
         return JSONResponse(
@@ -343,7 +343,7 @@ async def update_schema(item: schema_params):
             metadata_record=metadata_record,
             owner=item.requestor,
             event="UI Update Schema",
-            token=item.user_token,
+            token=token,
             eventid=eventid,
         )
         rootLogger.error(f"{eventid} : {response}")        
@@ -408,7 +408,7 @@ async def update_prop(item: prop_params):
             metadata_record=mcp,
             owner=item.requestor,
             event="UI Update Properties",
-            token=item.user_token,
+            token=token,
             eventid=eventid,
         )
         rootLogger.error(f"{eventid} : {response}")
@@ -609,7 +609,7 @@ async def create_item(item: create_dataset_params) -> None:
                 metadata_record=container_mcp,
                 owner=requestor,
                 event=f"Make-Dataset: update_container:{item.parentContainer}",
-                token=item.user_token,
+                token=token,
                 eventid=eventid
             )
         
@@ -643,7 +643,7 @@ async def delete_item(item: dataset_status_params) -> None:
             metadata_record=mce,
             owner=item.requestor,
             event=f"Status Update removed:{item.desired_state}",
-            token=item.user_token,
+            token=item.token,
             eventid=eventid,
         )
         rootLogger.error(f"{eventid} : {response}")
@@ -684,7 +684,7 @@ async def update_container(item: container_param) -> None:
             metadata_record=mcp,
             owner=item.requestor,
             event=f"Update container:{item.container}",
-            token=item.user_token,
+            token=token,
             eventid=eventid
         )
         rootLogger.error(f"{eventid} : {response}")
@@ -739,7 +739,7 @@ async def update_container(item: name_param) -> None:
             metadata_record=mcp,
             owner=item.requestor,
             event=f"Update dataset name:{item.displayName}",
-            token=item.user_token,
+            token=token,
             eventid=eventid
         )
         rootLogger.error(f"{eventid} : {response}")

--- a/metadata-service/war/src/main/resources/logback.xml
+++ b/metadata-service/war/src/main/resources/logback.xml
@@ -67,6 +67,9 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
+    <logger name="org.elasticsearch.client.RestClient" level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </logger>
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
To stop the eye bleeding number of GMS logs that warns about frozen indices. Despite not using frozen tier, the ES rest client interacts with 7.16 and always generate this warning message. If not suppressed, other way is to be solve by using newer ES versions