### PR TITLE
fixed bugs in openapi.py and openapi_parser.py

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -31,6 +31,7 @@ from datahub.ingestion.source.openapi_parser import (
     request_call,
     set_metadata,
     try_guessing,
+    flatten2list,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
@@ -247,7 +248,7 @@ class APISource(Source, ABC):
             # adding dataset fields
             if "data" in endpoint_dets.keys():
                 # we are lucky! data is defined in the swagger for this endpoint
-                schema_metadata = set_metadata(dataset_name, endpoint_dets["data"])
+                schema_metadata = set_metadata(dataset_name, flatten2list(endpoint_dets["data"]))
                 dataset_snapshot.aspects.append(schema_metadata)
                 yield self.build_wu(dataset_snapshot, dataset_name)
             elif (

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -22,7 +22,7 @@ def flatten(d: dict, prefix: str = "") -> Generator:
         if isinstance(v, dict):
             yield from flatten(v, f"{prefix}.{k}")
         else:
-            yield f"{prefix}-{k}".strip(".")
+            yield f"{prefix}.{k}".strip(".")
 
 
 def flatten2list(d: dict) -> list:

--- a/metadata-ingestion/tests/unit/test_openapi.py
+++ b/metadata-ingestion/tests/unit/test_openapi.py
@@ -385,7 +385,7 @@ class TestExplodeDict(unittest.TestCase):
         #  exploding keys of a dict...
         d = {"a": {"b": 3}, "c": 2, "asdasd": {"ytkhj": 2, "uylkj": 3}}
 
-        exp_l = ["a-b", "c", "asdasd-ytkhj", "asdasd-uylkj"]
+        exp_l = ["a.b", "c", "asdasd.ytkhj", "asdasd.uylkj"]
 
         cal_l = flatten2list(d)
         self.assertEqual(exp_l, cal_l)


### PR DESCRIPTION
extracting from openapi spec file and endpoint will generate differing aspects (data fields not captured correctly when parsing from spec file)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
