### PR TITLE
feat(gms): store update events in a new index in ElasticSearch

### DIFF
--- a/docker/elasticsearch-setup/create-indices.sh
+++ b/docker/elasticsearch-setup/create-indices.sh
@@ -107,6 +107,10 @@ function create_datahub_usage_event_datastream() {
   create_if_not_exists "_index_template/${PREFIX}datahub_usage_event_index_template" index_template.json
   #   3. although indexing request creates the data stream, it's not queryable before creation, causing GMS to throw exceptions
   create_if_not_exists "_data_stream/${PREFIX}datahub_usage_event" "datahub_usage_event"
+
+  # Create index template for update_events
+  create_if_not_exists "_index_template/${PREFIX}datahub_update_event_index_template" update_event_template.json
+  create_if_not_exists "_data_stream/${PREFIX}datahub_update_event" "datahub_update_event"
 }
 
 # create indices for ES OSS (AWS)

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -39,11 +39,9 @@ public interface EntitySearchService {
   void upsertDocument(@Nonnull String entityName, @Nonnull String document, @Nonnull String docId);
 
   /**
-   *
    * @param document the document to update into update index
-   * @param docId the ID of the document
    */
-  void createUpdateDocument(@Nonnull String document, @Nonnull String docId);
+  void createUpdateDocument(@Nonnull String document);
 
   /**
    * Deletes the document with the given document ID from the index.

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -38,6 +38,11 @@ public interface EntitySearchService {
    */
   void upsertDocument(@Nonnull String entityName, @Nonnull String document, @Nonnull String docId);
 
+  /**
+   *
+   * @param document the document to update into update index
+   * @param docId the ID of the document
+   */
   void createUpdateDocument(@Nonnull String document, @Nonnull String docId);
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -38,6 +38,8 @@ public interface EntitySearchService {
    */
   void upsertDocument(@Nonnull String entityName, @Nonnull String document, @Nonnull String docId);
 
+  void createUpdateDocument(@Nonnull String document, @Nonnull String docId);
+
   /**
    * Deletes the document with the given document ID from the index.
    *

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -70,6 +70,11 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
     esWriteDAO.upsertDocument(entityName, document, docId);
   }
 
+  public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
+    log.debug(String.format("Creating Update document document: %s, docId %s", document, docId));
+    esWriteDAO.createUpdateDocument(document, docId);
+  }
+
   @Override
   public void deleteDocument(@Nonnull String entityName, @Nonnull String docId) {
     log.debug(String.format("Deleting Search document entityName: %s, docId: %s", entityName, docId));

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -70,6 +70,7 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
     esWriteDAO.upsertDocument(entityName, document, docId);
   }
 
+  @Override
   public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
     log.debug(String.format("Creating Update document document: %s, docId %s", document, docId));
     esWriteDAO.createUpdateDocument(document, docId);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -71,9 +71,9 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
   }
 
   @Override
-  public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
-    log.debug(String.format("Creating Update document document: %s, docId %s", document, docId));
-    esWriteDAO.createUpdateDocument(document, docId);
+  public void createUpdateDocument(@Nonnull String document) {
+    log.debug(String.format("Creating Update document document: %s", document));
+    esWriteDAO.createUpdateDocument(document);
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -6,7 +6,9 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -44,6 +46,17 @@ public class ESWriteDAO {
             .retryOnConflict(numRetries);
 
     bulkProcessor.add(updateRequest);
+  }
+
+  public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
+    final String indexName = indexConvention.getIndexName("datahub_update_event");
+    final IndexRequest indexRequest = new IndexRequest(
+        indexName)
+        .id(docId)
+        .source(document, XContentType.JSON)
+        .opType(DocWriteRequest.OpType.CREATE);
+
+    bulkProcessor.add(indexRequest);
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -48,6 +48,12 @@ public class ESWriteDAO {
     bulkProcessor.add(updateRequest);
   }
 
+  /**
+   * Creates a request to insert new document into datahub_update_event index
+   *
+   * @param document the document to insert
+   * @param docId the ID of the document
+   */
   public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
     final String indexName = indexConvention.getIndexName("datahub_update_event");
     final IndexRequest indexRequest = new IndexRequest(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -52,13 +52,11 @@ public class ESWriteDAO {
    * Creates a request to insert new document into datahub_update_event index
    *
    * @param document the document to insert
-   * @param docId the ID of the document
    */
-  public void createUpdateDocument(@Nonnull String document, @Nonnull String docId) {
+  public void createUpdateDocument(@Nonnull String document) {
     final String indexName = indexConvention.getIndexName("datahub_update_event");
     final IndexRequest indexRequest = new IndexRequest(
         indexName)
-        .id(docId)
         .source(document, XContentType.JSON)
         .opType(DocWriteRequest.OpType.CREATE);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -84,7 +84,6 @@ public class SearchDocumentTransformer {
     return Optional.of(searchDocument.toString());
   }
 
-  //TODO: Transform event into a JSON-like string to upsert into search
   public String transformEvent(MetadataChangeLog event) {
     final ObjectNode searchDocument = JsonNodeFactory.instance.objectNode();
     searchDocument.put("urn", event.getEntityUrn().toString());

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.template.RecordTemplate;
@@ -14,6 +15,7 @@ import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation.FieldType;
 import com.linkedin.metadata.models.extractor.FieldExtractor;
 
+import com.linkedin.mxe.MetadataChangeLog;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +82,23 @@ public class SearchDocumentTransformer {
     extractedSearchableFields.forEach((key, values) -> setSearchableValue(key, values, searchDocument, forDelete));
     extractedSearchScoreFields.forEach((key, values) -> setSearchScoreValue(key, values, searchDocument, forDelete));
     return Optional.of(searchDocument.toString());
+  }
+
+  //TODO: Transform event into a JSON-like string to upsert into search
+  public String transformEvent(MetadataChangeLog event) {
+    final ObjectNode searchDocument = JsonNodeFactory.instance.objectNode();
+    searchDocument.put("urn", event.getEntityUrn().toString());
+    searchDocument.put("changeType", event.getChangeType().toString());
+    searchDocument.put("aspectName", event.getAspectName().toString());
+
+    AuditStamp eventCreationInfo = event.getCreated();
+    String actor = eventCreationInfo.getActor().toString();
+    Long time = eventCreationInfo.getTime();
+
+    searchDocument.put("actorUrn", actor);
+    searchDocument.put("timestamp", time);
+    searchDocument.put("@timestamp", time);
+    return searchDocument.toString();
   }
 
   public void setSearchableValue(final SearchableFieldSpec fieldSpec, final List<Object> fieldValues,

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -88,6 +88,7 @@ public class SearchDocumentTransformer {
     final ObjectNode searchDocument = JsonNodeFactory.instance.objectNode();
     searchDocument.put("urn", event.getEntityUrn().toString());
     searchDocument.put("changeType", event.getChangeType().toString());
+    searchDocument.put("entityType", event.getEntityType().toString());
     searchDocument.put("aspectName", event.getAspectName().toString());
 
     AuditStamp eventCreationInfo = event.getCreated();

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchUtils.java
@@ -2,7 +2,6 @@ package com.linkedin.metadata.search.utils;
 
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.data.ByteString;
 import com.linkedin.data.template.LongMap;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.query.SearchFlags;

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.search.utils;
 
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.ByteString;
 import com.linkedin.data.template.LongMap;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.query.SearchFlags;
@@ -22,6 +23,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +67,16 @@ public class SearchUtils {
     } catch (UnsupportedEncodingException e) {
       log.error("Failed to encode the urn with error: {}", e.toString());
       return Optional.empty();
+    }
+  }
+
+  public static String getDocHash(@Nonnull String aspectValue) {
+    try {
+      MessageDigest hashDigest = MessageDigest.getInstance("SHA-256");
+      String hashId = Base64.getEncoder().encodeToString(hashDigest.digest(aspectValue.getBytes(StandardCharsets.UTF_8)));
+      return hashId;
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -496,10 +496,6 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
    * Process event and update Update index in Elastic
    */
   private void updateUpdateIndex(@Nonnull final MetadataChangeLog event) {
-    // Events are only handled if their change type is UPDATE or DELETE
-    // Events with different change types still go through invoke but nothing is executed
-    // Doing the population of the event index allows us to capture deletes as well
-    // Should we check if the update is successful before populating update event index?
     String updateDocument = _searchDocumentTransformer.transformEvent(event);
 
     // Generating a hash using event urn, event content and time, to be used as a unique id for ES documents

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -497,13 +497,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
    */
   private void updateUpdateIndex(@Nonnull final MetadataChangeLog event) {
     String updateDocument = _searchDocumentTransformer.transformEvent(event);
-
-    // Generating a hash using event urn, event content and time, to be used as a unique id for ES documents
-    String stringToBeHashed = event.getEntityType().toString() + '_'
-        + event.getAspect().getValue().asAvroString()
-        + '_' + event.getCreated().getTime().toString();
-    String docHash = SearchUtils.getDocHash(stringToBeHashed);
-    _entitySearchService.createUpdateDocument(updateDocument, docHash);
+    _entitySearchService.createUpdateDocument(updateDocument);
   }
 
   private void updateSystemMetadata(SystemMetadata systemMetadata, Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {

--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/update_event_template.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/update_event_template.json
@@ -4,18 +4,31 @@
   "priority": 499,
   "template": {
     "mappings": {
+      "dynamic" : false,
       "properties": {
         "@timestamp": {
           "type": "date"
         },
-        "type": {
+        "urn": {
+          "type": "keyword"
+        },
+        "changeType": {
+          "type": "keyword"
+        },
+        "entityType": {
+          "type": "keyword"
+        },
+        "aspectName": {
+          "type": "keyword"
+        },
+        "actorUrn": {
           "type": "keyword"
         },
         "timestamp": {
           "type": "date"
         }
       }
-    },
+  },
     "settings": {
       "index.lifecycle.name": "PREFIXdatahub_usage_event_policy"
     }

--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/update_event_template.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/update_event_template.json
@@ -1,0 +1,23 @@
+{
+  "index_patterns": ["*PREFIXdatahub_update_event*"],
+  "data_stream": { },
+  "priority": 499,
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "timestamp": {
+          "type": "date"
+        }
+      }
+    },
+    "settings": {
+      "index.lifecycle.name": "PREFIXdatahub_usage_event_policy"
+    }
+  }
+}


### PR DESCRIPTION
Objective was to capture update events in ElasticSearch for metric-gathering purposes.

This PR makes the following changes:
- Creation of a ElasticSearch index, datahub-update-index
- Process events that are UPSERTs into JSON format that captures information such as time of the event, actor, aspect and entity urn
- Create a request for ElasticSearch to insert the new event into its index.
