### PR TITLE
feat(gms): add delete events into es index

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -238,6 +238,9 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
       deleteGraphData(urn, aspectSpec, aspect, isDeletingKey, event);
       deleteSearchData(urn, entitySpec.getName(), aspectSpec, aspect, isDeletingKey);
     }
+
+    // Populate update index with delete event
+    updateUpdateIndex(event);
   }
 
   // TODO: remove this method once we implement sourceOverride when creating graph edges


### PR DESCRIPTION
add delete events into es index as previous [pr](https://github.com/neojunjie/datahub/pull/135) only handled update events